### PR TITLE
chore: media addListeners and removeListeners are now public. 

### DIFF
--- a/src/channel/media.channel.ts
+++ b/src/channel/media.channel.ts
@@ -68,7 +68,14 @@ export class MediaChannel extends Channel {
         let media = new VideoMedia(mediaElement, this);
         for (const key in types) {
             if (types.hasOwnProperty(key)) {
+                let oldMedia: Media = this.medias[types[key]];
+                // remove listeners on old media element if any
+                if (oldMedia) {
+                    oldMedia.removeListeners();
+                }
                 this.medias[types[key]] = media;
+                // add listeners on new media element in order to have methods that depends on media status to work properly
+                media.addListeners();
             }
         }
     }

--- a/src/media/media.ts
+++ b/src/media/media.ts
@@ -146,13 +146,10 @@ export abstract class Media {
     return EnumError.NO_IMPLEMENTATION;
   }
 
-  protected abstract getMediaEvents();
-
   /**
    * Add Listeners
-   * @private
    */
-  protected addListeners(): void {
+  public addListeners(): void {
     const events: any = this.getMediaEvents();
     for (const event in events) {
       if (events.hasOwnProperty(event)) {
@@ -165,9 +162,8 @@ export abstract class Media {
 
   /**
    * Remove Listeners
-   * @private
    */
-  protected removeListeners(): void {
+  public removeListeners(): void {
     const events: any = this.getMediaEvents();
     for (const event in events) {
       if (events.hasOwnProperty(event)) {
@@ -175,6 +171,9 @@ export abstract class Media {
       }
     }
   }
+
+  protected abstract getMediaEvents();
+
   protected onUpdateMetadata(event): void {
     if (!this.mediaElement) {
       console.warn("MediaElement is null, ignore event ", event);


### PR DESCRIPTION
Use them to manage listeners on media element (addVideoMediaManager)
It is mandatory when using multiple video elements in a webapp and using addVideoMediaManager API